### PR TITLE
[caldav] - fetch vevent even when encapuslated with '<C:calendar-data'

### DIFF
--- a/backend/app/Services/CalDAVService.php
+++ b/backend/app/Services/CalDAVService.php
@@ -107,7 +107,7 @@ XML;
             $body = $response['body'];
             $events = [];
 
-            preg_match_all('/<cal:calendar-data[^>]*>(.*?)<\/cal:calendar-data>/s', $body, $matches);
+            preg_match_all('/<(?:cal|C):calendar-data[^>]*>(.*?)<\/(?:cal|C):calendar-data>/s', $body, $matches);
 
             foreach ($matches[1] as $icalData) {
                 $vcalendar = Reader::read($icalData);


### PR DESCRIPTION
Fetch vevent even when encapsulated with '<C:calendar-data …>' too

Observed, that events created with Evolution to radicale caldav server are not fetched. Turns out, that they are encapsulated like this:
```
 '<C:calendar-data>BEGIN:VCALENDAR ...... </C:calendar-data>' 
```
Proposed is a quick fix in the corresponding regular expression pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CalDAV event parsing to support variations in calendar-data tag prefixes, ensuring events sync correctly from more CalDAV servers (including those using uppercase namespace prefixes). Resolves cases where calendars appeared empty or missed events.
  * Increased reliability when processing multi-status responses from CalDAV servers, reducing the chance of missing events during sync. No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->