### PR TITLE
fix: Add onlyBuiltDependencies to pnpm lockfile settings

### DIFF
--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -3,6 +3,9 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  onlyBuiltDependencies:
+    - '@tailwindcss/oxide'
+    - esbuild
 
 importers:
 


### PR DESCRIPTION
pnpm uses the lockfile settings as the source of truth in CI. Without this, @tailwindcss/oxide and esbuild build scripts are blocked with ERR_PNPM_IGNORED_BUILDS in fresh Docker environments.