### PR TITLE
Feature/outlook fixes

### DIFF
--- a/backend/app/Console/Commands/RenewEventSubscriptions.php
+++ b/backend/app/Console/Commands/RenewEventSubscriptions.php
@@ -133,8 +133,10 @@ class RenewEventSubscriptions extends Command
         try {
             $calendar = $display->calendar;
 
+            // Room mailboxes cannot be subscribed to via delegated auth in Microsoft Graph
+            // (/users/{room-email}/events is rejected for Exchange resource mailboxes).
+            // Events are still fetched via polling — skip silently like Google rooms do.
             if ($calendar->room) {
-                $outlookService->createEventSubscriptionByUser($outlookAccount, $display, $calendar->calendar_id);
                 return;
             }
 

--- a/backend/app/Services/OutlookService.php
+++ b/backend/app/Services/OutlookService.php
@@ -186,7 +186,7 @@ class OutlookService
             $outlookAccount->update([
                 'status' => AccountStatus::ERROR,
             ]);
-            throw new Exception('Error refreshing Outlook token: ' . Arr::get($tokenData, 'error.message'));
+            throw new Exception('Error refreshing Outlook token: ' . ($tokenData['error'] ?? '') . ' - ' . ($tokenData['error_description'] ?? ''));
         }
 
         $outlookAccount->update([

--- a/backend/app/Services/OutlookService.php
+++ b/backend/app/Services/OutlookService.php
@@ -11,6 +11,7 @@ use App\Models\OutlookAccount;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 class OutlookService
@@ -40,8 +41,24 @@ class OutlookService
             return;
         }
 
-        // Set the access token for API requests
-        $this->refreshToken($outlookAccount);
+        // Use a lock to prevent concurrent refreshes causing rotating refresh token invalidation.
+        // Multiple PHP processes hitting an expired token simultaneously would each try to refresh,
+        // but only the first succeeds — subsequent ones use the now-rotated (invalid) old token.
+        $lock = Cache::lock('outlook_token_refresh_' . $outlookAccount->id, 30);
+        $lock->block(15);
+
+        try {
+            // Re-read from DB — another process may have already refreshed while we waited
+            $outlookAccount = $outlookAccount->fresh();
+
+            if (now()->lte($outlookAccount->token_expires_at)) {
+                return;
+            }
+
+            $this->refreshToken($outlookAccount);
+        } finally {
+            $lock->release();
+        }
     }
 
     /**


### PR DESCRIPTION
## Microsoft 365 / Outlook Integration Fixes
This PR addresses three separate but related issues affecting Microsoft 365 calendar integrations on self-hosted deployments.

### 1. Exchange Room Mailboxes Causing Displays to Enter ERROR Status
Problem: When the RenewEventSubscriptions scheduled command ran, it attempted to create a Microsoft Graph webhook subscription for Exchange room mailboxes using delegated authentication (/users/{room-email}/events). Microsoft Graph rejects this for Exchange resource mailboxes — the Graph API does not support delegated webhook subscriptions on room/resource mailboxes. This caused the command to throw an exception, which the error handler caught and set the display status to ERROR.

_Fix:_ Added an early return for calendars that have an associated room, skipping webhook subscription creation entirely. Room calendar events are already fetched via polling on each sync cycle — the same approach Google room calendars use. The display status remains healthy and events continue to sync correctly.

### 2. Token Refresh Failures Producing Blank Error Messages
Problem: When an Outlook OAuth token refresh failed (e.g. due to AADSTS50173 token revocation or AADSTS65001 consent required), the thrown exception message was always empty. The code was using Arr::get($tokenData, 'error.message') to extract the error detail, but Microsoft's OAuth error responses use error and error_description as flat keys — not a nested error.message structure. This made diagnosing token refresh failures extremely difficult as no useful error information appeared in the logs.

_Fix:_ Changed the error extraction to use $tokenData['error'] and $tokenData['error_description'] directly, which matches the actual OAuth 2.0 error response format.

### 3. Concurrent Token Refresh Race Condition (AADSTS50173 — Token Revoked)
Problem: Self-hosted deployments using NGINX Unit (or any multi-process PHP server) run multiple worker processes simultaneously. When a stored OAuth token expired, multiple PHP processes would hit ensureAuthenticated() at the same moment and each independently decide the token needed refreshing. All processes would then fire off a refresh request to Microsoft using the same (now expired) refresh token.

Microsoft rotates refresh tokens on use — the first process to succeed would receive a new token pair, which immediately invalidated the old refresh token. All subsequent processes were now holding an invalidated refresh token and would receive AADSTS50173: The token has been revoked errors. This caused a cascading failure pattern where every process except the first would put the Outlook account into ERROR status, requiring manual token re-authentication.

_Fix:_ Wrapped the token refresh logic in a Cache::lock() with a 30-second TTL and a 15-second block timeout. After acquiring the lock, the process re-reads the account from the database before proceeding — if another process already refreshed the token while this one was waiting, the fresh token is valid and no refresh is needed. Only one process performs the actual refresh; all others transparently pick up the new token from the database.

`$lock = Cache::lock('outlook_token_refresh_' . $outlookAccount->id, 30);`
`$lock->block(15);`
`try {`
`    $outlookAccount = $outlookAccount->fresh();`
`    if (now()->lte($outlookAccount->token_expires_at)) {`
`        return; // Already refreshed by another process`
`    }`
`    $this->refreshToken($outlookAccount);`
`} finally {`
`    $lock->release();`
`}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved token refresh reliability by preventing concurrent refresh requests from invalidating authentication.
  * Enhanced error messages for authentication failures with clearer error details.
  * Fixed Outlook room mailbox subscription handling to prevent invalid subscription attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magweter/spacepad/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->